### PR TITLE
Bump v0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 lib/
-**/nestjs-plugins-test
+nestjs-plugins-test
 /nestjs-plugins
+.changelog/
 
 ### https://raw.github.com/github/gitignore/6c87d249af5f2b3f8ab65ae0a2648682ee4e8a2d/Node.gitignore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## Unreleased (2020-03-16)
+
+#### :rocket: Enhancement
+
+- `nestjs-slack-webhook`
+  - [#37](https://github.com/piic/nestjs-plugins/pull/37) rename: package nestjs-slack-webhook ([@Yasai-T](https://github.com/Yasai-T))
+- `nestjs-slack`
+  - [#25](https://github.com/piic/nestjs-plugins/pull/25) feat: nestjs-slack plugin ([@Yasai-T](https://github.com/Yasai-T))
+
+#### Committers: 2
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+- tomoki midorikawa ([@Yasai-T](https://github.com/Yasai-T))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased (2020-03-16)
+## v0.0.2 (2020-03-16)
 
 #### :rocket: Enhancement
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "TBA",
   "license": "MIT",
@@ -30,8 +30,8 @@
     "@types/graphql": "^14.5.0",
     "apollo-server-express": "^2.11.0",
     "graphql": "^14.6.0",
-    "nestjs-graphql-relay": "^0.0.1",
-    "nestjs-slack-webhook": "^0.0.1",
+    "nestjs-graphql-relay": "^0.0.2",
+    "nestjs-slack-webhook": "^0.0.2",
     "reflect-metadata": "0.1.13",
     "rxjs": "^6.5.4",
     "typeorm": "0.2.24"

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,5 @@
 {
-  "packages": [
-    "packages/*",
-    "example"
-  ],
+  "packages": ["packages/*", "example"],
   "changelog": {
     "labels": {
       "enhancement": ":rocket: Enhancement",
@@ -12,5 +9,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nestjs-plugins",
   "private": true,
+  "repository": "git@github.com:piic/nestjs-plugins.git",
   "author": "piic",
   "scripts": {
     "build": "lerna run build --include-dependents",

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-graphql-relay",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Nest.js + graphql-relay + type-graphql + typeorm",
   "repository": {
     "type": "git",

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestjs-graphql-relay",
   "version": "0.0.2",
-  "description": "Nest.js + graphql-relay + type-graphql + typeorm",
+  "description": "@nestjs/graphql + graphql-relay +typeorm",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/piic/nestjs-plugins.git"
@@ -21,6 +21,9 @@
     "type-graphql",
     "typeorm"
   ],
+  "peerDependencies": {
+    "@nestjs/graphql": "^7.0.0"
+  },
   "devDependencies": {
     "@types/graphql": "14.5.0",
     "@types/graphql-relay": "0.4.11",

--- a/packages/nestjs-slack-webhook/package.json
+++ b/packages/nestjs-slack-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-slack-webhook",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Nest.js + slack-webhook",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
     "slack-webhook"
   ],
   "devDependencies": {
-    "@slack/webhook": "5.0.3",
-    "@nestjs/testing": "7.0.2"
+    "@nestjs/testing": "7.0.2",
+    "@slack/webhook": "5.0.3"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
## v0.0.2 (2020-03-16)

#### :rocket: Enhancement

- `nestjs-slack-webhook`
  - [#37](https://github.com/piic/nestjs-plugins/pull/37) rename: package nestjs-slack-webhook ([@Yasai-T](https://github.com/Yasai-T))
- `nestjs-slack`
  - [#25](https://github.com/piic/nestjs-plugins/pull/25) feat: nestjs-slack plugin ([@Yasai-T](https://github.com/Yasai-T))

#### Committers: 2

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
- tomoki midorikawa ([@Yasai-T](https://github.com/Yasai-T))