### PR TITLE
Bump v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.0.3 (2020-05-18)
+
+#### :rocket: Enhancement
+
+- `nestjs-graphql-relay`
+  - [#152](https://github.com/piic/nestjs-plugins/pull/152) fix: skip aggregate ([@9renpoto](https://github.com/9renpoto))
+- `nestjs-graphql-relay`, `nestjs-slack-webhook`
+  - [#91](https://github.com/piic/nestjs-plugins/pull/91) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v0.0.2 (2020-03-16)
 
 #### :rocket: Enhancement

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "description": "TBA",
   "license": "MIT",
@@ -29,8 +29,8 @@
     "@types/graphql": "^14.5.0",
     "apollo-server-express": "^2.12.0",
     "graphql": "^14.6.0",
-    "nestjs-graphql-relay": "^0.0.2",
-    "nestjs-slack-webhook": "^0.0.2",
+    "nestjs-graphql-relay": "^0.0.3",
+    "nestjs-slack-webhook": "^0.0.3",
     "reflect-metadata": "0.1.13",
     "rxjs": "^6.5.5",
     "typeorm": "0.2.24"

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-graphql-relay",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "@nestjs/graphql + graphql-relay +typeorm",
   "repository": {
     "type": "git",

--- a/packages/nestjs-slack-webhook/package.json
+++ b/packages/nestjs-slack-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-slack-webhook",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Nest.js + slack-webhook",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.0.3 (2020-05-18)

#### :rocket: Enhancement

- `nestjs-graphql-relay`
  - [#152](https://github.com/piic/nestjs-plugins/pull/152) fix: skip aggregate ([@9renpoto](https://github.com/9renpoto))
- `nestjs-graphql-relay`, `nestjs-slack-webhook`
  - [#91](https://github.com/piic/nestjs-plugins/pull/91) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))